### PR TITLE
#64 Fixed a `JsonMappingException` error when deserializing various types…

### DIFF
--- a/src/main/java/javaslang/jackson/datatype/deserialize/ArrayDeserializer.java
+++ b/src/main/java/javaslang/jackson/datatype/deserialize/ArrayDeserializer.java
@@ -40,8 +40,16 @@ abstract class ArrayDeserializer<T> extends ValueDeserializer<T> {
     public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         JsonDeserializer<?> deserializer = deserializer(0);
         List<Object> list = new ArrayList<>();
-        while (p.nextToken() != JsonToken.END_ARRAY) {
-            list.add(deserializer.deserialize(p, ctxt));
+
+        JsonToken jsonToken;
+        while ((jsonToken = p.nextToken()) != JsonToken.END_ARRAY) {
+            Object value;
+            if (jsonToken == JsonToken.VALUE_NULL) {
+                value = deserializer.getNullValue(ctxt);
+            } else {
+                value = deserializer.deserialize(p, ctxt);
+            }
+            list.add(value);
         }
         return create(list, ctxt);
     }

--- a/src/main/java/javaslang/jackson/datatype/deserialize/ArrayDeserializer.java
+++ b/src/main/java/javaslang/jackson/datatype/deserialize/ArrayDeserializer.java
@@ -26,6 +26,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
+import static com.fasterxml.jackson.core.JsonToken.VALUE_NULL;
+
 abstract class ArrayDeserializer<T> extends ValueDeserializer<T> {
 
     private static final long serialVersionUID = 1L;
@@ -40,15 +43,8 @@ abstract class ArrayDeserializer<T> extends ValueDeserializer<T> {
     public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         JsonDeserializer<?> deserializer = deserializer(0);
         List<Object> list = new ArrayList<>();
-
-        JsonToken jsonToken;
-        while ((jsonToken = p.nextToken()) != JsonToken.END_ARRAY) {
-            Object value;
-            if (jsonToken == JsonToken.VALUE_NULL) {
-                value = deserializer.getNullValue(ctxt);
-            } else {
-                value = deserializer.deserialize(p, ctxt);
-            }
+        for (JsonToken jsonToken = p.nextToken(); jsonToken != END_ARRAY; jsonToken = p.nextToken()) {
+            Object value = (jsonToken != VALUE_NULL) ? deserializer.deserialize(p, ctxt) : deserializer.getNullValue(ctxt);
             list.add(value);
         }
         return create(list, ctxt);

--- a/src/main/java/javaslang/jackson/datatype/deserialize/EitherDeserializer.java
+++ b/src/main/java/javaslang/jackson/datatype/deserialize/EitherDeserializer.java
@@ -21,9 +21,10 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import javaslang.control.Either;
 
 import java.io.IOException;
+
+import javaslang.control.Either;
 
 class EitherDeserializer extends ValueDeserializer<Either<?, ?>> {
 
@@ -42,7 +43,9 @@ class EitherDeserializer extends ValueDeserializer<Either<?, ?>> {
         boolean right = false;
         Object value = null;
         int cnt = 0;
-        while (p.nextToken() != JsonToken.END_ARRAY) {
+
+        JsonToken jsonToken;
+        while ((jsonToken = p.nextToken()) != JsonToken.END_ARRAY) {
             cnt++;
             switch (cnt) {
                 case 1:
@@ -56,10 +59,16 @@ class EitherDeserializer extends ValueDeserializer<Either<?, ?>> {
                     }
                     break;
                 case 2:
+                    JsonDeserializer<?> deserializer;
                     if (right) {
-                        value = deserializer(1).deserialize(p, ctxt);
+                        deserializer = deserializer(1);
                     } else {
-                        value = deserializer(0).deserialize(p, ctxt);
+                        deserializer = deserializer(0);
+                    }
+                    if (jsonToken == JsonToken.VALUE_NULL) {
+                        value = deserializer.getNullValue(ctxt);
+                    } else {
+                        value = deserializer.deserialize(p, ctxt);
                     }
                     break;
             }

--- a/src/main/java/javaslang/jackson/datatype/deserialize/TupleDeserializer.java
+++ b/src/main/java/javaslang/jackson/datatype/deserialize/TupleDeserializer.java
@@ -37,6 +37,9 @@ import javaslang.Tuple5;
 import javaslang.Tuple6;
 import javaslang.Tuple7;
 
+import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
+import static com.fasterxml.jackson.core.JsonToken.VALUE_NULL;
+
 class TupleDeserializer extends ValueDeserializer<Tuple> {
 
     private static final long serialVersionUID = 1L;
@@ -53,18 +56,12 @@ class TupleDeserializer extends ValueDeserializer<Tuple> {
         List<Object> list = new ArrayList<>();
         int ptr = 0;
 
-        JsonToken jsonToken;
-        while ((jsonToken = p.nextToken()) != JsonToken.END_ARRAY) {
+        for (JsonToken jsonToken = p.nextToken(); jsonToken != END_ARRAY; jsonToken = p.nextToken()) {
             if (ptr >= deserializersCount()) {
                 throw ctxt.mappingException(javaType.getRawClass());
             }
-            Object value;
             JsonDeserializer<?> deserializer = deserializer(ptr++);
-            if (jsonToken == JsonToken.VALUE_NULL) {
-                value = deserializer.getNullValue(ctxt);
-            } else {
-                value = deserializer.deserialize(p, ctxt);
-            }
+            Object value = (jsonToken != VALUE_NULL) ? deserializer.deserialize(p, ctxt) : deserializer.getNullValue(ctxt);
             list.add(value);
         }
         return create(list, ctxt);

--- a/src/main/java/javaslang/jackson/datatype/deserialize/TupleDeserializer.java
+++ b/src/main/java/javaslang/jackson/datatype/deserialize/TupleDeserializer.java
@@ -20,12 +20,22 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import javaslang.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import javaslang.Tuple;
+import javaslang.Tuple0;
+import javaslang.Tuple1;
+import javaslang.Tuple2;
+import javaslang.Tuple3;
+import javaslang.Tuple4;
+import javaslang.Tuple5;
+import javaslang.Tuple6;
+import javaslang.Tuple7;
 
 class TupleDeserializer extends ValueDeserializer<Tuple> {
 
@@ -42,11 +52,20 @@ class TupleDeserializer extends ValueDeserializer<Tuple> {
     public Tuple deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
         List<Object> list = new ArrayList<>();
         int ptr = 0;
-        while (p.nextToken() != JsonToken.END_ARRAY) {
+
+        JsonToken jsonToken;
+        while ((jsonToken = p.nextToken()) != JsonToken.END_ARRAY) {
             if (ptr >= deserializersCount()) {
                 throw ctxt.mappingException(javaType.getRawClass());
             }
-            list.add(deserializer(ptr++).deserialize(p, ctxt));
+            Object value;
+            JsonDeserializer<?> deserializer = deserializer(ptr++);
+            if (jsonToken == JsonToken.VALUE_NULL) {
+                value = deserializer.getNullValue(ctxt);
+            } else {
+                value = deserializer.deserialize(p, ctxt);
+            }
+            list.add(value);
         }
         return create(list, ctxt);
     }

--- a/src/test/java/javaslang/jackson/datatype/BaseTest.java
+++ b/src/test/java/javaslang/jackson/datatype/BaseTest.java
@@ -1,11 +1,19 @@
 package javaslang.jackson.datatype;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import javaslang.collection.Seq;
+import com.fasterxml.jackson.databind.ObjectWriter;
 
+import org.junit.Assert;
+
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+
+import javaslang.Tuple2;
+import javaslang.collection.List;
+import javaslang.collection.Seq;
 
 public class BaseTest {
 
@@ -15,6 +23,20 @@ public class BaseTest {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY)
     protected interface WrapperArray {
+    }
+
+    protected void verifySerialization(TypeReference<?> typeReference, List<Tuple2<?, String>> testValues) throws IOException {
+        ObjectWriter writer = mapper().writerFor(typeReference);
+        for (Tuple2<?, String> testValue : testValues) {
+            Object src = testValue._1();
+            String expectedJson = testValue._2();
+
+            String json = writer.writeValueAsString(src);
+            Assert.assertEquals(expectedJson, json);
+
+            Object dst = mapper().readValue(json, typeReference);
+            Assert.assertEquals(src, dst);
+        }
     }
 
     protected ObjectMapper mapper() {
@@ -60,10 +82,10 @@ public class BaseTest {
             }
             sb.append("\"").append(entry.getKey().toString()).append("\":");
             Object value = entry.getValue();
-            if(value instanceof Collection) {
+            if (value instanceof Collection) {
                 sb.append("[");
                 int j = 0;
-                for (Object v: ((Collection) value)) {
+                for (Object v : ((Collection) value)) {
                     if (j > 0) {
                         sb.append(",");
                     }

--- a/src/test/java/javaslang/jackson/datatype/EitherTest.java
+++ b/src/test/java/javaslang/jackson/datatype/EitherTest.java
@@ -2,14 +2,21 @@ package javaslang.jackson.datatype;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import javaslang.collection.HashSet;
-import javaslang.collection.List;
-import javaslang.collection.Set;
-import javaslang.control.Either;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import javaslang.Tuple;
+import javaslang.collection.HashSet;
+import javaslang.collection.List;
+import javaslang.collection.Set;
+import javaslang.control.Either;
+import javaslang.control.Option;
+
+import static javaslang.control.Option.none;
+import static javaslang.control.Option.some;
 
 public class EitherTest extends BaseTest {
 
@@ -72,4 +79,16 @@ public class EitherTest extends BaseTest {
         Either<List<Integer>, Set<Double>> restored = mapper().readValue(json, new TypeReference<Either<List<Integer>, Set<Double>>>() {});
         Assert.assertEquals(either, restored);
     }
+
+    @Test
+    public void testWithOption() throws IOException {
+        TypeReference<Either<Option<String>, Option<String>>> typeReference = new TypeReference<Either<Option<String>, Option<String>>>() {};
+        verifySerialization(typeReference, List.of(
+                Tuple.of(Either.left(none()), genJsonList("left", null)),
+                Tuple.of(Either.right(none()), genJsonList("right", null)),
+                Tuple.of(Either.left(some("value")), genJsonList("left", "value")),
+                Tuple.of(Either.right(some("value")), genJsonList("right", "value"))
+        ));
+    }
+
 }

--- a/src/test/java/javaslang/jackson/datatype/map/HashMapTest.java
+++ b/src/test/java/javaslang/jackson/datatype/map/HashMapTest.java
@@ -1,11 +1,15 @@
 package javaslang.jackson.datatype.map;
 
-import javaslang.collection.HashMap;
-import javaslang.collection.Map;
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import javaslang.collection.HashMap;
+import javaslang.collection.Map;
+import javaslang.control.Option;
 
 public class HashMapTest extends MapTest {
     @Override
@@ -16,6 +20,11 @@ public class HashMapTest extends MapTest {
     @Override
     <K, V> Map<K, V> emptyMap() {
         return HashMap.empty();
+    }
+
+    @Override
+    protected TypeReference<HashMap<String, Option<Integer>>> typeReferenceWithOption() {
+        return new TypeReference<HashMap<String, Option<Integer>>>() {};
     }
 
     @Test

--- a/src/test/java/javaslang/jackson/datatype/map/LinkedHashMapTest.java
+++ b/src/test/java/javaslang/jackson/datatype/map/LinkedHashMapTest.java
@@ -1,11 +1,15 @@
 package javaslang.jackson.datatype.map;
 
-import javaslang.collection.LinkedHashMap;
-import javaslang.collection.Map;
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import javaslang.collection.LinkedHashMap;
+import javaslang.collection.Map;
+import javaslang.control.Option;
 
 public class LinkedHashMapTest extends MapTest {
     @Override
@@ -16,6 +20,11 @@ public class LinkedHashMapTest extends MapTest {
     @Override
     <K, V> Map<K, V> emptyMap() {
         return LinkedHashMap.empty();
+    }
+
+    @Override
+    protected TypeReference<LinkedHashMap<String, Option<Integer>>> typeReferenceWithOption() {
+        return new TypeReference<LinkedHashMap<String, Option<Integer>>>() {};
     }
 
     @Test

--- a/src/test/java/javaslang/jackson/datatype/map/MapTest.java
+++ b/src/test/java/javaslang/jackson/datatype/map/MapTest.java
@@ -1,19 +1,28 @@
 package javaslang.jackson.datatype.map;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import javaslang.collection.Map;
-import javaslang.jackson.datatype.BaseTest;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import javaslang.Tuple;
+import javaslang.collection.HashMap;
+import javaslang.collection.List;
+import javaslang.collection.Map;
+import javaslang.control.Option;
+import javaslang.jackson.datatype.BaseTest;
 
 public abstract class MapTest extends BaseTest {
 
     abstract Class<?> clz();
 
     abstract <K, V> Map<K, V> emptyMap();
+
+    protected abstract TypeReference<? extends Map<String, Option<Integer>>> typeReferenceWithOption();
 
     @Test
     public void test1() throws IOException {
@@ -53,5 +62,13 @@ public abstract class MapTest extends BaseTest {
     @Test(expected = JsonParseException.class)
     public void test4() throws IOException {
         mapper().readValue("{1: 1}", clz());
+    }
+
+    @Test
+    public void testWithOption() throws Exception {
+        verifySerialization(typeReferenceWithOption(), List.of(
+                Tuple.of(emptyMap().put("1", Option.some(1)), genJsonMap(HashMap.of("1", 1).toJavaMap())),
+                Tuple.of(emptyMap().put("1", Option.none()), genJsonMap(HashMap.of("1", null).toJavaMap()))
+        ));
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/map/TreeMapTest.java
+++ b/src/test/java/javaslang/jackson/datatype/map/TreeMapTest.java
@@ -1,12 +1,20 @@
 package javaslang.jackson.datatype.map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.collection.Map;
 import javaslang.collection.TreeMap;
+import javaslang.control.Option;
 
 public class TreeMapTest extends MapTest {
     @Override
     Class<?> clz() {
         return TreeMap.class;
+    }
+
+    @Override
+    protected TypeReference<TreeMap<String, Option<Integer>>> typeReferenceWithOption() {
+        return new TypeReference<TreeMap<String, Option<Integer>>>() {};
     }
 
     @Override

--- a/src/test/java/javaslang/jackson/datatype/multimap/HashMultimapTest.java
+++ b/src/test/java/javaslang/jackson/datatype/multimap/HashMultimapTest.java
@@ -1,7 +1,10 @@
 package javaslang.jackson.datatype.multimap;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.collection.HashMultimap;
 import javaslang.collection.Multimap;
+import javaslang.control.Option;
 
 public class HashMultimapTest extends MultimapTest {
     @Override
@@ -12,5 +15,10 @@ public class HashMultimapTest extends MultimapTest {
     @Override
     <K, V> Multimap<K, V> emptyMap() {
         return HashMultimap.withSeq().empty();
+    }
+
+    @Override
+    protected TypeReference<HashMultimap<String, Option<Integer>>> typeReferenceWithOption() {
+        return new TypeReference<HashMultimap<String, Option<Integer>>>() {};
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/multimap/LinkedHashMultimapTest.java
+++ b/src/test/java/javaslang/jackson/datatype/multimap/LinkedHashMultimapTest.java
@@ -1,12 +1,16 @@
 package javaslang.jackson.datatype.multimap;
 
-import javaslang.collection.LinkedHashMultimap;
-import javaslang.collection.Multimap;
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
+
+import javaslang.collection.LinkedHashMultimap;
+import javaslang.collection.Multimap;
+import javaslang.control.Option;
 
 public class LinkedHashMultimapTest extends MultimapTest {
     @Override
@@ -17,6 +21,11 @@ public class LinkedHashMultimapTest extends MultimapTest {
     @Override
     <K, V> Multimap<K, V> emptyMap() {
         return LinkedHashMultimap.withSeq().empty();
+    }
+
+    @Override
+    protected TypeReference<LinkedHashMultimap<String, Option<Integer>>> typeReferenceWithOption() {
+        return new TypeReference<LinkedHashMultimap<String, Option<Integer>>>() {};
     }
 
     @Test

--- a/src/test/java/javaslang/jackson/datatype/multimap/MultimapTest.java
+++ b/src/test/java/javaslang/jackson/datatype/multimap/MultimapTest.java
@@ -1,7 +1,7 @@
 package javaslang.jackson.datatype.multimap;
 
-import javaslang.collection.Multimap;
-import javaslang.jackson.datatype.BaseTest;
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -10,11 +10,21 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javaslang.Tuple;
+import javaslang.collection.HashMap;
+import javaslang.collection.Multimap;
+import javaslang.control.Option;
+import javaslang.jackson.datatype.BaseTest;
+
+import static java.util.Arrays.asList;
+
 public abstract class MultimapTest extends BaseTest {
 
     abstract Class<?> clz();
 
     abstract <K, V> Multimap<K, V> emptyMap();
+
+    protected abstract TypeReference<? extends Multimap<String, Option<Integer>>> typeReferenceWithOption();
 
     @Test
     public void test1() throws IOException {
@@ -31,4 +41,13 @@ public abstract class MultimapTest extends BaseTest {
         Multimap<?, ?> restored = (Multimap<?, ?>) mapper().readValue(json, clz());
         Assert.assertEquals(restored, javaslangObject);
     }
+
+    @Test
+    public void testWithOption() throws Exception {
+        Multimap<String, Option<Integer>> multimap = this.<String, Option<Integer>>emptyMap().put("1", Option.some(1)).put("1", Option.none());
+        String json = genJsonMap(HashMap.of("1", asList(1, null)).toJavaMap());
+
+        verifySerialization(typeReferenceWithOption(), javaslang.collection.List.of(Tuple.of(multimap, json)));
+    }
+
 }

--- a/src/test/java/javaslang/jackson/datatype/multimap/TreeMultimapTest.java
+++ b/src/test/java/javaslang/jackson/datatype/multimap/TreeMultimapTest.java
@@ -1,7 +1,10 @@
 package javaslang.jackson.datatype.multimap;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.collection.Multimap;
 import javaslang.collection.TreeMultimap;
+import javaslang.control.Option;
 
 public class TreeMultimapTest extends MultimapTest {
     @Override
@@ -12,5 +15,10 @@ public class TreeMultimapTest extends MultimapTest {
     @Override
     <K, V> Multimap<K, V> emptyMap() {
         return TreeMultimap.withSeq().empty((o1, o2) -> o1.toString().compareTo(o2.toString()));
+    }
+
+    @Override
+    protected TypeReference<TreeMultimap<String, Option<Integer>>> typeReferenceWithOption() {
+        return new TypeReference<TreeMultimap<String, Option<Integer>>>() {};
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/seq/ArrayTest.java
+++ b/src/test/java/javaslang/jackson/datatype/seq/ArrayTest.java
@@ -1,14 +1,22 @@
 package javaslang.jackson.datatype.seq;
 
-import javaslang.collection.Array;
-import javaslang.collection.Seq;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import java.util.Arrays;
+
+import javaslang.collection.Array;
+import javaslang.collection.Seq;
+import javaslang.control.Option;
 
 public class ArrayTest extends SeqTest {
     @Override
     protected Class<?> clz() {
         return Array.class;
+    }
+
+    @Override
+    protected TypeReference<Array<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Array<Option<String>>>() {};
     }
 
     @Override

--- a/src/test/java/javaslang/jackson/datatype/seq/ListTest.java
+++ b/src/test/java/javaslang/jackson/datatype/seq/ListTest.java
@@ -1,18 +1,27 @@
 package javaslang.jackson.datatype.seq;
 
-import javaslang.collection.List;
-import javaslang.collection.Seq;
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 
+import javaslang.collection.List;
+import javaslang.collection.Seq;
+import javaslang.control.Option;
+
 public class ListTest extends SeqTest {
 
     @Override
     protected Class<?> clz() {
         return List.class;
+    }
+
+    @Override
+    protected TypeReference<List<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<List<Option<String>>>() {};
     }
 
     @Override

--- a/src/test/java/javaslang/jackson/datatype/seq/QueueTest.java
+++ b/src/test/java/javaslang/jackson/datatype/seq/QueueTest.java
@@ -1,14 +1,22 @@
 package javaslang.jackson.datatype.seq;
 
-import javaslang.collection.Queue;
-import javaslang.collection.Seq;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import java.util.Arrays;
+
+import javaslang.collection.Queue;
+import javaslang.collection.Seq;
+import javaslang.control.Option;
 
 public class QueueTest extends SeqTest {
     @Override
     protected Class<?> clz() {
         return Queue.class;
+    }
+
+    @Override
+    protected TypeReference<Queue<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Queue<Option<String>>>() {};
     }
 
     @Override

--- a/src/test/java/javaslang/jackson/datatype/seq/SeqTest.java
+++ b/src/test/java/javaslang/jackson/datatype/seq/SeqTest.java
@@ -1,23 +1,31 @@
 package javaslang.jackson.datatype.seq;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import javaslang.collection.Seq;
-import javaslang.jackson.datatype.BaseTest;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 
+import javaslang.Tuple;
+import javaslang.collection.List;
+import javaslang.collection.Seq;
+import javaslang.control.Option;
+import javaslang.jackson.datatype.BaseTest;
+
 public abstract class SeqTest extends BaseTest {
 
-    abstract Class<?> clz();
+    protected abstract Class<?> clz();
+
+    protected abstract TypeReference<? extends Seq<Option<String>>> typeReferenceWithOption();
 
     protected String implClzName() {
         return clz().getName();
     }
 
-    abstract Seq<?> of(Object... objects);
+    protected abstract Seq<?> of(Object... objects);
 
     @Test
     public void test1() throws IOException {
@@ -49,5 +57,13 @@ public abstract class SeqTest extends BaseTest {
         Assert.assertEquals(wrappedJson, wrapToArray(implClzName(), plainJson));
         Seq<?> restored = (Seq<?>) mapper.readValue(wrappedJson, clz());
         Assert.assertEquals(src, restored);
+    }
+
+    @Test
+    public void testWithOption() throws Exception {
+        verifySerialization(typeReferenceWithOption(), List.of(
+                Tuple.of(of(Option.some("value")), genJsonList("value")),
+                Tuple.of(of(Option.none()), genJsonList((Object) null))
+        ));
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/seq/StreamTest.java
+++ b/src/test/java/javaslang/jackson/datatype/seq/StreamTest.java
@@ -1,14 +1,22 @@
 package javaslang.jackson.datatype.seq;
 
-import javaslang.collection.Seq;
-import javaslang.collection.Stream;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import java.util.Arrays;
+
+import javaslang.collection.Seq;
+import javaslang.collection.Stream;
+import javaslang.control.Option;
 
 public class StreamTest extends SeqTest {
     @Override
     protected Class<?> clz() {
         return Stream.class;
+    }
+
+    @Override
+    protected TypeReference<Stream<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Stream<Option<String>>>() {};
     }
 
     @Override

--- a/src/test/java/javaslang/jackson/datatype/seq/VectorTest.java
+++ b/src/test/java/javaslang/jackson/datatype/seq/VectorTest.java
@@ -1,14 +1,22 @@
 package javaslang.jackson.datatype.seq;
 
-import javaslang.collection.Seq;
-import javaslang.collection.Vector;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import java.util.Arrays;
+
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
 
 public class VectorTest extends SeqTest {
     @Override
     protected Class<?> clz() {
         return Vector.class;
+    }
+
+    @Override
+    protected TypeReference<Vector<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Vector<Option<String>>>() {};
     }
 
     @Override

--- a/src/test/java/javaslang/jackson/datatype/set/HashSetTest.java
+++ b/src/test/java/javaslang/jackson/datatype/set/HashSetTest.java
@@ -1,28 +1,36 @@
 package javaslang.jackson.datatype.set;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import javaslang.collection.HashSet;
-import javaslang.collection.Set;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 
+import javaslang.collection.HashSet;
+import javaslang.collection.Set;
+import javaslang.control.Option;
+
 public class HashSetTest extends SetTest {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return HashSet.class;
     }
 
     @Override
-    TypeReference<?> typeReference() {
+    protected TypeReference<HashSet<Integer>> typeReference() {
         return new TypeReference<HashSet<Integer>>() {};
     }
 
     @Override
-    Set<Integer> of(Integer... objects) {
+    protected TypeReference<HashSet<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<HashSet<Option<String>>>() {};
+    }
+
+    @Override
+    protected Set<?> of(Object... objects) {
         return HashSet.ofAll(Arrays.asList(objects));
     }
 

--- a/src/test/java/javaslang/jackson/datatype/set/LinkedHashSetTest.java
+++ b/src/test/java/javaslang/jackson/datatype/set/LinkedHashSetTest.java
@@ -1,28 +1,36 @@
 package javaslang.jackson.datatype.set;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import javaslang.collection.LinkedHashSet;
-import javaslang.collection.Set;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 
+import javaslang.collection.LinkedHashSet;
+import javaslang.collection.Set;
+import javaslang.control.Option;
+
 public class LinkedHashSetTest extends SetTest {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return LinkedHashSet.class;
     }
 
     @Override
-    TypeReference<?> typeReference() {
+    protected TypeReference<LinkedHashSet<Integer>> typeReference() {
         return new TypeReference<LinkedHashSet<Integer>>() {};
     }
 
     @Override
-    Set<Integer> of(Integer... objects) {
+    protected TypeReference<LinkedHashSet<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<LinkedHashSet<Option<String>>>() {};
+    }
+
+    @Override
+    protected Set<?> of(Object... objects) {
         return LinkedHashSet.ofAll(Arrays.asList(objects));
     }
 

--- a/src/test/java/javaslang/jackson/datatype/set/SetTest.java
+++ b/src/test/java/javaslang/jackson/datatype/set/SetTest.java
@@ -3,28 +3,35 @@ package javaslang.jackson.datatype.set;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import javaslang.collection.Set;
-import javaslang.jackson.datatype.BaseTest;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 
+import javaslang.Tuple;
+import javaslang.collection.List;
+import javaslang.collection.Set;
+import javaslang.control.Option;
+import javaslang.jackson.datatype.BaseTest;
+
 public abstract class SetTest extends BaseTest {
 
-    abstract Class<?> clz();
+    protected abstract Class<?> clz();
 
-    abstract TypeReference<?> typeReference();
+    protected abstract TypeReference<? extends Set<Integer>> typeReference();
 
-    abstract Set<Integer> of(Integer... objects);
+    protected abstract TypeReference<? extends Set<Option<String>>> typeReferenceWithOption();
+
+    protected abstract Set<?> of(Object... objects);
 
     @Test
     public void test1() throws IOException {
         ObjectWriter writer = mapper().writer();
-        Set<Integer> src = of(1, 2, 5);
+        Set<?> src = of(1, 2, 5);
         String json = writer.writeValueAsString(src);
         Assert.assertEquals(genJsonList(1, 2, 5), json);
-        Set<Integer> dst = mapper().readValue(json, typeReference());
+        Set<?> dst = mapper().readValue(json, typeReference());
         Assert.assertEquals(src, dst);
     }
 
@@ -48,5 +55,13 @@ public abstract class SetTest extends BaseTest {
         Assert.assertEquals(wrappedJson, wrapToArray(clz().getName(), plainJson));
         Set<?> restored = mapper.readValue(wrappedJson, typeReference());
         Assert.assertEquals(src, restored);
+    }
+
+    @Test
+    public void testWithOption() throws Exception {
+        verifySerialization(typeReferenceWithOption(), List.of(
+                Tuple.of(of(Option.some("value")), genJsonList("value")),
+                Tuple.of(of(Option.none()), genJsonList((Object) null))
+        ));
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/set/TreeSetTest.java
+++ b/src/test/java/javaslang/jackson/datatype/set/TreeSetTest.java
@@ -2,27 +2,40 @@ package javaslang.jackson.datatype.set;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import javaslang.collection.Set;
-import javaslang.collection.TreeSet;
+
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Comparator;
+
+import javaslang.collection.List;
+import javaslang.collection.Set;
+import javaslang.collection.TreeSet;
+import javaslang.control.Option;
 
 public class TreeSetTest extends SetTest {
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return TreeSet.class;
     }
 
     @Override
-    TypeReference<?> typeReference() {
-        return new TypeReference<TreeSet<Integer>>() {};
+    protected TypeReference<TreeSet<Integer>> typeReference() {
+        return new TypeReference<TreeSet<Integer>>() {
+        };
     }
 
     @Override
-    Set<Integer> of(Integer... objects) {
-        return TreeSet.ofAll(Integer::compareTo, Arrays.asList(objects));
+    protected TypeReference<TreeSet<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<TreeSet<Option<String>>>() {
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Set<?> of(Object... objects) {
+        List<Comparable<Object>> comparables = List.of(objects).map(value -> (Comparable<Object>) value);
+        return TreeSet.ofAll(Comparator.naturalOrder(), comparables);
     }
 
     @Test(expected = JsonMappingException.class)
@@ -33,6 +46,11 @@ public class TreeSetTest extends SetTest {
     @Test(expected = JsonMappingException.class)
     public void testGeneric2() throws IOException {
         mapper().readValue("[1, 2]", new TypeReference<TreeSet<Object>>() {});
+    }
+
+    @Override
+    public void testWithOption() throws IOException {
+        // there is nothing to test, because Option is not Comparable and we cannot deserialize a TreeSet<Option<? extends Comparable<?>>
     }
 
     static class Incomparable {

--- a/src/test/java/javaslang/jackson/datatype/tuples/Tuple1Test.java
+++ b/src/test/java/javaslang/jackson/datatype/tuples/Tuple1Test.java
@@ -1,22 +1,30 @@
 package javaslang.jackson.datatype.tuples;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.Tuple;
 import javaslang.Tuple1;
+import javaslang.control.Option;
 
 public class Tuple1Test extends TupleTest<Tuple1<?>> {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return Tuple1.class;
     }
 
     @Override
-    int arity() {
+    protected int arity() {
         return 1;
     }
 
     @Override
-    Tuple1<?> ofObjects(Object head, Object tail) {
+    protected Tuple1<?> ofObjects(Object head, Object tail) {
         return Tuple.of(head);
+    }
+
+    @Override
+    protected TypeReference<Tuple1<Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Tuple1<Option<String>>>() {};
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/tuples/Tuple2Test.java
+++ b/src/test/java/javaslang/jackson/datatype/tuples/Tuple2Test.java
@@ -1,22 +1,30 @@
 package javaslang.jackson.datatype.tuples;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.Tuple;
 import javaslang.Tuple2;
+import javaslang.control.Option;
 
 public class Tuple2Test extends TupleTest<Tuple2<?, ?>> {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return Tuple2.class;
     }
 
     @Override
-    int arity() {
+    protected int arity() {
         return 2;
     }
 
     @Override
-    Tuple2<?, ?> ofObjects(Object head, Object tail) {
+    protected Tuple2<?, ?> ofObjects(Object head, Object tail) {
         return Tuple.of(head, tail);
+    }
+
+    @Override
+    protected TypeReference<Tuple2<Option<String>, Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Tuple2<Option<String>, Option<String>>>() {};
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/tuples/Tuple3Test.java
+++ b/src/test/java/javaslang/jackson/datatype/tuples/Tuple3Test.java
@@ -1,22 +1,30 @@
 package javaslang.jackson.datatype.tuples;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.Tuple;
 import javaslang.Tuple3;
+import javaslang.control.Option;
 
 public class Tuple3Test extends TupleTest<Tuple3<?, ?, ?>> {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return Tuple3.class;
     }
 
     @Override
-    int arity() {
+    protected int arity() {
         return 3;
     }
 
     @Override
-    Tuple3<?, ?, ?> ofObjects(Object head, Object tail) {
+    protected Tuple3<?, ?, ?> ofObjects(Object head, Object tail) {
         return Tuple.of(head, tail, tail);
+    }
+
+    @Override
+    protected TypeReference<Tuple3<Option<String>, Option<String>, Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Tuple3<Option<String>, Option<String>, Option<String>>>() {};
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/tuples/Tuple4Test.java
+++ b/src/test/java/javaslang/jackson/datatype/tuples/Tuple4Test.java
@@ -1,22 +1,30 @@
 package javaslang.jackson.datatype.tuples;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.Tuple;
 import javaslang.Tuple4;
+import javaslang.control.Option;
 
 public class Tuple4Test extends TupleTest<Tuple4<?, ?, ?, ?>> {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return Tuple4.class;
     }
 
     @Override
-    int arity() {
+    protected int arity() {
         return 4;
     }
 
     @Override
-    Tuple4<?, ?, ?, ?> ofObjects(Object head, Object tail) {
+    protected Tuple4<?, ?, ?, ?> ofObjects(Object head, Object tail) {
         return Tuple.of(head, tail, tail, tail);
+    }
+
+    @Override
+    protected TypeReference<Tuple4<Option<String>, Option<String>, Option<String>, Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Tuple4<Option<String>, Option<String>, Option<String>, Option<String>>>() {};
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/tuples/Tuple5Test.java
+++ b/src/test/java/javaslang/jackson/datatype/tuples/Tuple5Test.java
@@ -1,22 +1,30 @@
 package javaslang.jackson.datatype.tuples;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.Tuple;
 import javaslang.Tuple5;
+import javaslang.control.Option;
 
 public class Tuple5Test extends TupleTest<Tuple5<?, ?, ?, ?, ?>> {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return Tuple5.class;
     }
 
     @Override
-    int arity() {
+    protected int arity() {
         return 5;
     }
 
     @Override
-    Tuple5<?, ?, ?, ?, ?> ofObjects(Object head, Object tail) {
+    protected Tuple5<?, ?, ?, ?, ?> ofObjects(Object head, Object tail) {
         return Tuple.of(head, tail, tail, tail, tail);
+    }
+
+    @Override
+    protected TypeReference<Tuple5<Option<String>, Option<String>, Option<String>, Option<String>, Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Tuple5<Option<String>, Option<String>, Option<String>, Option<String>, Option<String>>>() {};
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/tuples/Tuple6Test.java
+++ b/src/test/java/javaslang/jackson/datatype/tuples/Tuple6Test.java
@@ -1,22 +1,30 @@
 package javaslang.jackson.datatype.tuples;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.Tuple;
 import javaslang.Tuple6;
+import javaslang.control.Option;
 
 public class Tuple6Test extends TupleTest<Tuple6<?, ?, ?, ?, ?, ?>> {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return Tuple6.class;
     }
 
     @Override
-    int arity() {
+    protected int arity() {
         return 6;
     }
 
     @Override
-    Tuple6<?, ?, ?, ?, ?, ?> ofObjects(Object head, Object tail) {
+    protected Tuple6<?, ?, ?, ?, ?, ?> ofObjects(Object head, Object tail) {
         return Tuple.of(head, tail, tail, tail, tail, tail);
+    }
+
+    @Override
+    protected TypeReference<Tuple6<Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Tuple6<Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>>>() {};
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/tuples/Tuple7Test.java
+++ b/src/test/java/javaslang/jackson/datatype/tuples/Tuple7Test.java
@@ -1,22 +1,30 @@
 package javaslang.jackson.datatype.tuples;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.Tuple;
 import javaslang.Tuple7;
+import javaslang.control.Option;
 
 public class Tuple7Test extends TupleTest<Tuple7<?, ?, ?, ?, ?, ?, ?>> {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return Tuple7.class;
     }
 
     @Override
-    int arity() {
+    protected int arity() {
         return 7;
     }
 
     @Override
-    Tuple7<?, ?, ?, ?, ?, ?, ?> ofObjects(Object head, Object tail) {
+    protected Tuple7<?, ?, ?, ?, ?, ?, ?> ofObjects(Object head, Object tail) {
         return Tuple.of(head, tail, tail, tail, tail, tail, tail);
+    }
+
+    @Override
+    protected TypeReference<Tuple7<Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Tuple7<Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>>>() {};
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/tuples/Tuple8Test.java
+++ b/src/test/java/javaslang/jackson/datatype/tuples/Tuple8Test.java
@@ -1,22 +1,30 @@
 package javaslang.jackson.datatype.tuples;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import javaslang.Tuple;
 import javaslang.Tuple8;
+import javaslang.control.Option;
 
 public class Tuple8Test extends TupleTest<Tuple8<?, ?, ?, ?, ?, ?, ?, ?>> {
 
     @Override
-    Class<?> clz() {
+    protected Class<?> clz() {
         return Tuple8.class;
     }
 
     @Override
-    int arity() {
+    protected int arity() {
         return 8;
     }
 
     @Override
-    Tuple8<?, ?, ?, ?, ?, ?, ?, ?> ofObjects(Object head, Object tail) {
+    protected Tuple8<?, ?, ?, ?, ?, ?, ?, ?> ofObjects(Object head, Object tail) {
         return Tuple.of(head, tail, tail, tail, tail, tail, tail, tail);
+    }
+
+    @Override
+    protected TypeReference<Tuple8<Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>>> typeReferenceWithOption() {
+        return new TypeReference<Tuple8<Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>>>() {};
     }
 }


### PR DESCRIPTION
… when the data contains `Option.none()`.

The types include `Seq` and subtypes, `Set` types, `Either`, and `TupleN`. Map and Multimap is apparently not affected, when using Option the value type.

The idea behind the fix is, that while deserializing, if the current token is a `VALUE_NULL` token, then the appropriate deserializer's `nullValue` needs to be used, instead of just trying to deserialize like otherwise.

Also included new tests to cover this scenario. Written tests for maps and multimaps, even though they do not seem to be effected with the current codebase. 