### PR TITLE
Fixed bug with deserializing to SortedSet interface

### DIFF
--- a/src/main/java/javaslang/jackson/datatype/deserialize/SetDeserializer.java
+++ b/src/main/java/javaslang/jackson/datatype/deserialize/SetDeserializer.java
@@ -37,7 +37,7 @@ class SetDeserializer extends ArrayDeserializer<Set<?>> {
     @SuppressWarnings("unchecked")
     @Override
     Set<?> create(List<Object> result, DeserializationContext ctx) throws JsonMappingException {
-        if (javaslang.collection.TreeSet.class.isAssignableFrom(javaType.getRawClass())) {
+        if (javaslang.collection.SortedSet.class.isAssignableFrom(javaType.getRawClass())) {
             if (javaType.containedTypeCount() == 0) {
                 throw ctx.mappingException(javaType.getRawClass());
             }

--- a/src/test/java/javaslang/jackson/datatype/set/TreeSetTest.java
+++ b/src/test/java/javaslang/jackson/datatype/set/TreeSetTest.java
@@ -3,15 +3,16 @@ package javaslang.jackson.datatype.set;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
+import javaslang.collection.*;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Comparator;
+import java.util.Objects;
 
-import javaslang.collection.List;
-import javaslang.collection.Set;
-import javaslang.collection.TreeSet;
 import javaslang.control.Option;
+
+import static org.junit.Assert.assertEquals;
 
 public class TreeSetTest extends SetTest {
     @Override
@@ -36,6 +37,26 @@ public class TreeSetTest extends SetTest {
     protected Set<?> of(Object... objects) {
         List<Comparable<Object>> comparables = List.of(objects).map(value -> (Comparable<Object>) value);
         return TreeSet.ofAll(Comparator.naturalOrder(), comparables);
+    }
+
+    static class Clazz{
+        private SortedSet<Integer> set;
+        public SortedSet<Integer> getSet() {return set;}
+        public void setSet(SortedSet<Integer> set) {this.set = set;}
+        public boolean equals(Object o){
+            return Objects.equals(set, ((Clazz)o).set);
+        }
+        public int hashCode(){
+            return set.hashCode();
+        }
+    }
+
+    @Test
+    public void testDeserializeToSortedSet() throws IOException {
+        Clazz c = new Clazz();
+        c.setSet(TreeSet.of(1, 3, 5));
+        Clazz dc = mapper().readValue(mapper().writeValueAsString(c), Clazz.class);
+        assertEquals(c, dc);
     }
 
     @Test(expected = JsonMappingException.class)


### PR DESCRIPTION
addresses #73
TreeSet is now used for all SortedSet types instead of just TreeSet types
added test to test deserializing into SortedSet