### PR TITLE
xml annotations support (bug #82)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,18 @@
             <version>${fasterxml.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${fasterxml.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
+            <version>${fasterxml.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/javaslang/jackson/datatype/JavaslangModule.java
+++ b/src/main/java/javaslang/jackson/datatype/JavaslangModule.java
@@ -61,5 +61,6 @@ public class JavaslangModule extends SimpleModule {
     public void setupModule(SetupContext context) {
         context.addSerializers(new JavaslangSerializers(settings));
         context.addDeserializers(new JavaslangDeserializers(settings));
+        context.addTypeModifier(new JavaslangTypeModifier());
     }
 }

--- a/src/main/java/javaslang/jackson/datatype/JavaslangTypeModifier.java
+++ b/src/main/java/javaslang/jackson/datatype/JavaslangTypeModifier.java
@@ -15,11 +15,12 @@ public class JavaslangTypeModifier extends TypeModifier {
         if (type.isReferenceType() || type.isContainerType()) {
             return type;
         }
-
         final Class<?> raw = type.getRawClass();
-        if (raw == List.class) {
-            return CollectionLikeType.construct(
-                raw, type.containedTypeOrUnknown(0));
+        if (Seq.class.isAssignableFrom(raw) && CharSeq.class != raw) {
+            return CollectionLikeType.construct(raw, type.containedTypeOrUnknown(0));
+        }
+        if (Set.class.isAssignableFrom(raw)) {
+            return CollectionLikeType.construct(raw, type.containedTypeOrUnknown(0));
         }
         return type;
     }

--- a/src/main/java/javaslang/jackson/datatype/JavaslangTypeModifier.java
+++ b/src/main/java/javaslang/jackson/datatype/JavaslangTypeModifier.java
@@ -1,0 +1,26 @@
+package javaslang.jackson.datatype;
+
+import java.lang.reflect.Type;
+
+import javaslang.collection.*;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.*;
+
+public class JavaslangTypeModifier extends TypeModifier {
+
+    @Override
+    public JavaType modifyType(JavaType type, Type jdkType, TypeBindings bindings, TypeFactory typeFactory)
+    {
+        if (type.isReferenceType() || type.isContainerType()) {
+            return type;
+        }
+
+        final Class<?> raw = type.getRawClass();
+        if (raw == List.class) {
+            return CollectionLikeType.construct(
+                raw, type.containedTypeOrUnknown(0));
+        }
+        return type;
+    }
+}

--- a/src/main/java/javaslang/jackson/datatype/deserialize/JavaslangDeserializers.java
+++ b/src/main/java/javaslang/jackson/datatype/deserialize/JavaslangDeserializers.java
@@ -17,6 +17,8 @@ package javaslang.jackson.datatype.deserialize;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.Deserializers;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.type.CollectionLikeType;
 import javaslang.Lazy;
 import javaslang.Tuple;
 import javaslang.collection.*;
@@ -62,17 +64,26 @@ public class JavaslangDeserializers extends Deserializers.Base {
         if (Tuple.class.isAssignableFrom(raw)) {
             return new TupleDeserializer(type);
         }
+        if (λ.class.isAssignableFrom(raw)) {
+            return new SerializableDeserializer<>(type);
+        }
+
+        return super.findBeanDeserializer(type, config, beanDesc);
+    }
+
+    @Override
+    public JsonDeserializer<?> findCollectionLikeDeserializer(CollectionLikeType type,
+                                                              DeserializationConfig config, BeanDescription beanDesc,
+                                                              TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer)
+            throws JsonMappingException
+    {
+        Class<?> raw = type.getRawClass();
         if (Seq.class.isAssignableFrom(raw)) {
             return new SeqDeserializer(type, settings.deserializeNullAsEmptyCollection());
         }
         if (Set.class.isAssignableFrom(raw)) {
             return new SetDeserializer(type, settings.deserializeNullAsEmptyCollection());
         }
-
-        if (λ.class.isAssignableFrom(raw)) {
-            return new SerializableDeserializer<>(type);
-        }
-
-        return null;
+        return super.findCollectionLikeDeserializer(type, config, beanDesc, elementTypeDeserializer, elementDeserializer);
     }
 }

--- a/src/main/java/javaslang/jackson/datatype/serialize/JavaslangSerializers.java
+++ b/src/main/java/javaslang/jackson/datatype/serialize/JavaslangSerializers.java
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.Serializers;
+import com.fasterxml.jackson.databind.type.CollectionLikeType;
 import javaslang.Lazy;
 import javaslang.Tuple;
 import javaslang.collection.*;
@@ -56,12 +58,6 @@ public class JavaslangSerializers extends Serializers.Base {
         if (PriorityQueue.class.isAssignableFrom(raw)) {
             return new ArraySerializer<>(type);
         }
-        if (Seq.class.isAssignableFrom(raw)) {
-            return new ArraySerializer<>(type);
-        }
-        if (Set.class.isAssignableFrom(raw)) {
-            return new ArraySerializer<>(type);
-        }
         if (Map.class.isAssignableFrom(raw)) {
             return new MapSerializer(type);
         }
@@ -77,5 +73,19 @@ public class JavaslangSerializers extends Serializers.Base {
         }
 
         return super.findSerializer(config, type, beanDesc);
+    }
+
+    @Override
+    public JsonSerializer<?> findCollectionLikeSerializer(SerializationConfig config,
+                                                          CollectionLikeType type, BeanDescription beanDesc,
+                                                          TypeSerializer elementTypeSerializer, JsonSerializer<Object> elementValueSerializer) {
+        Class<?> raw = type.getRawClass();
+        if (Seq.class.isAssignableFrom(raw)) {
+            return new ArraySerializer<>(type);
+        }
+        if (Set.class.isAssignableFrom(raw)) {
+            return new ArraySerializer<>(type);
+        }
+        return super.findCollectionLikeSerializer(config, type, beanDesc, elementTypeSerializer, elementValueSerializer);
     }
 }

--- a/src/test/java/javaslang/jackson/datatype/BaseTest.java
+++ b/src/test/java/javaslang/jackson/datatype/BaseTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 import org.junit.Assert;
 
@@ -49,6 +51,19 @@ public class BaseTest {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaslangModule(settings));
         return mapper;
+    }
+
+    public XmlMapper xmlMapper() {
+        XmlMapper xmlMapper = new XmlMapper();
+        xmlMapper.registerModule(new JavaslangModule());
+        return xmlMapper;
+    }
+
+    public XmlMapper xmlMapperJaxb() {
+        XmlMapper xmlMapper = new XmlMapper();
+        xmlMapper.registerModule(new JaxbAnnotationModule());
+        xmlMapper.registerModule(new JavaslangModule());
+        return xmlMapper;
     }
 
     protected String wrapToArray(String as, String json) {

--- a/src/test/java/javaslang/jackson/datatype/seq/ListTest.java
+++ b/src/test/java/javaslang/jackson/datatype/seq/ListTest.java
@@ -3,6 +3,13 @@ package javaslang.jackson.datatype.seq;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -65,5 +72,53 @@ public class ListTest extends SeqTest {
         A restored = mapper().readValue(javaUtilValue, A.class);
         Assert.assertEquals("hello", restored.f.head().type);
     }
+  @XmlRootElement(name = "xmlSerialize")
+    private static class JaxbXmlSerializeJavaslang {
+        @XmlElementWrapper(name = "transitTypes")
+        @XmlElement(name = "transitType")
+        public List<Integer> transitTypes = List.of(1, 2, 3);
+    }
 
+    @XmlRootElement(name = "xmlSerialize")
+    private static class JaxbXmlSerializeJavaUtil {
+        @XmlElementWrapper(name = "transitTypes")
+        @XmlElement(name = "transitType")
+        public java.util.List<Integer> transitTypes = new java.util.ArrayList<>();
+
+        public JaxbXmlSerializeJavaUtil() {
+            transitTypes.add(1);
+            transitTypes.add(2);
+            transitTypes.add(3);
+        }
+    }
+
+    @Test
+    public void testJaxbXmlSerialization() throws IOException {
+        String javaUtilValue = xmlMapperJaxb().writeValueAsString(new JaxbXmlSerializeJavaslang());
+        Assert.assertEquals(xmlMapperJaxb().writeValueAsString(new JaxbXmlSerializeJavaUtil()), javaUtilValue);
+    }
+
+    private static class XmlSerializeJavaslang {
+        @JacksonXmlElementWrapper(localName = "transitTypes")
+        @JsonProperty("transitType")
+        public List<Integer> transitTypes = List.of(1, 2, 3);
+    }
+
+    private static class XmlSerializeJavaUtil {
+        @JacksonXmlElementWrapper(localName = "transitTypes")
+        @JsonProperty("transitType")
+        public java.util.List<Integer> transitTypes = new java.util.ArrayList<>();
+
+        public XmlSerializeJavaUtil() {
+            transitTypes.add(1);
+            transitTypes.add(2);
+            transitTypes.add(3);
+        }
+    }
+
+    @Test
+    public void testXmlSerialization() throws IOException {
+        String javaUtilValue = xmlMapper().writeValueAsString(new XmlSerializeJavaslang());
+        Assert.assertEquals(xmlMapper().writeValueAsString(new XmlSerializeJavaUtil()), javaUtilValue);
+    }
 }

--- a/src/test/java/javaslang/jackson/datatype/seq/ListTest.java
+++ b/src/test/java/javaslang/jackson/datatype/seq/ListTest.java
@@ -9,6 +9,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import org.junit.Assert;
@@ -72,7 +73,8 @@ public class ListTest extends SeqTest {
         A restored = mapper().readValue(javaUtilValue, A.class);
         Assert.assertEquals("hello", restored.f.head().type);
     }
-  @XmlRootElement(name = "xmlSerialize")
+
+    @XmlRootElement(name = "xmlSerialize")
     private static class JaxbXmlSerializeJavaslang {
         @XmlElementWrapper(name = "transitTypes")
         @XmlElement(name = "transitType")
@@ -98,12 +100,14 @@ public class ListTest extends SeqTest {
         Assert.assertEquals(xmlMapperJaxb().writeValueAsString(new JaxbXmlSerializeJavaUtil()), javaUtilValue);
     }
 
+    @JacksonXmlRootElement(localName = "xmlSerialize")
     private static class XmlSerializeJavaslang {
         @JacksonXmlElementWrapper(localName = "transitTypes")
         @JsonProperty("transitType")
         public List<Integer> transitTypes = List.of(1, 2, 3);
     }
 
+    @JacksonXmlRootElement(localName = "xmlSerialize")
     private static class XmlSerializeJavaUtil {
         @JacksonXmlElementWrapper(localName = "transitTypes")
         @JsonProperty("transitType")

--- a/src/test/java/javaslang/jackson/datatype/set/SetTest.java
+++ b/src/test/java/javaslang/jackson/datatype/set/SetTest.java
@@ -3,16 +3,25 @@ package javaslang.jackson.datatype.set;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javaslang.jackson.datatype.JavaslangModule;
 import org.junit.Assert;
 import org.junit.Test;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import java.io.IOException;
 
 import javaslang.Tuple;
 import javaslang.collection.List;
 import javaslang.collection.Set;
+import javaslang.collection.HashSet;
 import javaslang.control.Option;
 import javaslang.jackson.datatype.BaseTest;
 
@@ -88,5 +97,57 @@ public abstract class SetTest extends BaseTest {
                 Tuple.of(of(Option.some("value")), genJsonList("value")),
                 Tuple.of(of(Option.none()), genJsonList((Object) null))
         ));
+    }
+
+    @XmlRootElement(name = "xmlSerialize")
+    private static class JaxbXmlSerializeJavaslang {
+        @XmlElementWrapper(name = "transitTypes")
+        @XmlElement(name = "transitType")
+        public Set<Integer> transitTypes = HashSet.of(1, 2, 3);
+    }
+
+    @XmlRootElement(name = "xmlSerialize")
+    private static class JaxbXmlSerializeJavaUtil {
+        @XmlElementWrapper(name = "transitTypes")
+        @XmlElement(name = "transitType")
+        public java.util.Set<Integer> transitTypes = new java.util.HashSet<>();
+
+        public JaxbXmlSerializeJavaUtil() {
+            transitTypes.add(1);
+            transitTypes.add(2);
+            transitTypes.add(3);
+        }
+    }
+
+    @Test
+    public void testJaxbXmlSerialization() throws IOException {
+        String javaUtilValue = xmlMapperJaxb().writeValueAsString(new JaxbXmlSerializeJavaslang());
+        Assert.assertEquals(xmlMapperJaxb().writeValueAsString(new JaxbXmlSerializeJavaUtil()), javaUtilValue);
+    }
+
+    @JacksonXmlRootElement(localName = "xmlSerialize")
+    private static class XmlSerializeJavaslang {
+        @JacksonXmlElementWrapper(localName = "transitTypes")
+        @JsonProperty("transitType")
+        public Set<Integer> transitTypes = HashSet.of(1, 2, 3);
+    }
+
+    @JacksonXmlRootElement(localName = "xmlSerialize")
+    private static class XmlSerializeJavaUtil {
+        @JacksonXmlElementWrapper(localName = "transitTypes")
+        @JsonProperty("transitType")
+        public java.util.Set<Integer> transitTypes = new java.util.HashSet<>();
+
+        public XmlSerializeJavaUtil() {
+            transitTypes.add(1);
+            transitTypes.add(2);
+            transitTypes.add(3);
+        }
+    }
+
+    @Test
+    public void testXmlSerialization() throws IOException {
+        String javaUtilValue = xmlMapper().writeValueAsString(new XmlSerializeJavaslang());
+        Assert.assertEquals(xmlMapper().writeValueAsString(new XmlSerializeJavaUtil()), javaUtilValue);
     }
 }


### PR DESCRIPTION
fix bug #82. Actually after your commit it was already working, it was just a flaw in the test itself :-)

I added a Set test, you mentioned adding a Seq test but I'm not sure because Seq is abstract? Let me know what you would add and I can add it!

PS: I guess we'll have to wait for the next javaslang release for this to be released after being merged?